### PR TITLE
What I just upgraded

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -27,3 +27,15 @@ Tips:
   - Keep captures SHORT and focused on a single UI flow to isolate 3–8 packets quickly.
   - The YAML is intentionally simple; edit field notes as you learn payload structures.
   - Re-run 'analyze' after a new capture to grow your proto map incrementally.
+
+
+Advanced usage:
+
+  # Multi-port capture (ConnectServer + GameServer)
+  python mu_wire_kit.py proxy-multi --pairs 0.0.0.0:44405->127.0.0.1:44405,0.0.0.0:55901->127.0.0.1:55901 --logdir ./logs
+
+  # Filter just F3 subcodes 03 and 30 from client→server
+  python mu_wire_kit.py proxy --listen 0.0.0.0:55901 --target 127.0.0.1:55901 --log ./mu.log --only-dir C→S --only-head F3 --only-sub 03,30
+
+  # Generate MuEmu-style stubs
+  python mu_wire_kit.py gen --yaml ./proto.yaml --out ./stubs --style muemu


### PR DESCRIPTION
What I just upgraded
C3/C4 support (besides C1/C2) — so encrypted/checksummed frames are recognized and logged.

Packet filters on the proxy:

--only-dir C→S|S→C

--only-head F3,FB

--only-sub 03,30

Multi-port capture: proxy-multi lets you log ConnectServer + GameServer at the same time.

Stub generator styles: --style muemu emits MUEMU-style recv/send skeletons (PBMSG/PSBMSG layout).

README updated with the new commands.


Quick examples (copy/paste)

Capture both ports at once:

python mu_wire_kit.py proxy-multi \
  --pairs 0.0.0.0:44405->127.0.0.1:44405,0.0.0.0:55901->127.0.0.1:55901 \
  --logdir ./logs


Only log Event/MST stuff (example F3 head, subs 03 and 30) from client→server:

python mu_wire_kit.py proxy \
  --listen 0.0.0.0:55901 --target 127.0.0.1:55901 --log ./mu.log \
  --only-dir C→S --only-head F3 --only-sub 03,30


Generate MuEmu-style stubs:

python mu_wire_kit.py gen --yaml ./proto.yaml --out ./stubs --style muemu